### PR TITLE
Propose `simple` word better translation

### DIFF
--- a/content/home/examples/a-simple-component.md
+++ b/content/home/examples/a-simple-component.md
@@ -1,5 +1,5 @@
 ---
-title: مكّون بسيط
+title: مكّون سهل
 order: 0
 domid: hello-example
 ---


### PR DESCRIPTION
In the Arabic language, the correct translation of `simple` is `سهل` not `بسيط`.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
